### PR TITLE
Flask in kubernetes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ The steps include:
 * Deployment of MySQL and Flask app using **separate Dockerfiles** and Bash scripts for automatic provisioning
 * Deployment of MYSQL and Flask app using **Docker-Compose**
 * Deployment of dockerized MySQL and Flask app in **Kubernetes cluster** using **simple YAML configuration**
-* Deployment o dockerized MySQL and Flask app in **Kubernetes cluster** using YAML configuration + **Kustomize templating**
-* Deployment o dockerized MySQL and Flask app in **Kubernetes cluster** using **Helm Charts**
+* Deployment o dockerized MySQL and Flask app in Kubernetes cluster using YAML configuration + **Kustomize templating**
+* Deployment o dockerized MySQL and Flask app in Kubernetes cluster using **Helm Charts**
 
 Apart from moving the application to Kubernetes, future planned additions include:
 
@@ -23,9 +23,11 @@ Apart from moving the application to Kubernetes, future planned additions includ
 
 ## Flask app setup
 
-Application is modified to use MySQL database instead of in-memory SQLite3.
+Application is modified to use external MySQL database instead of in-memory SQLite3.  
+MySQL database instance is listening on port `3306` (default).  
+In directory `db/` there is an init script `schema.sql`, which is responsible for creating the database, tables and user to be used by Flask application.
 
-## Running Application using deployment script (separate Dockerfiles) - v1.0.0
+### Running Application using deployment script (separate Dockerfiles) - v1.0.0
 
 ```bash
 chmod +x scripts/deploy.sh
@@ -38,9 +40,9 @@ chmod +x scripts/deploy.sh
 
 You can pass an additional `--prune` flag to remove all the existing resources before provisioning new ones using the script.
 
-## Running Application using docker compose - v2.0.0
+### Running Application using docker compose - v2.0.0
 
-`docker-compose.yaml` file defined at root directory of the project can be used to deploy a containerized stack of Flask and MySQL instances.  
+File `docker-compose.yaml` defined at root directory of the project can be used to deploy a containerized stack of Flask and MySQL instances.  
 It works out the same way as `scripts/deploy.sh`, but with addition of automatic network creation, easy env variable support and health checks, as well as restarting the containers on failure automatically.
 
 To validate the compose file, with resolved environment variable:
@@ -61,6 +63,61 @@ To remove stack and any related volumes / orphan containers:
 docker compose down -v --remove-orphans
 ```
 
-## Kubernetes setup
+### Kubernetes setup - Kind
 
-Kubernetes cluster consists of two worker nodes and one control-plane node, all running K8s v1.26.0
+Kubernetes cluster consists of two worker nodes and one control-plane node, all running K8s v1.26.0, deployed using [Kind](https://kind.sigs.k8s.io/).  
+The config file for Kind Cluster is defined in `kind-example-config.yaml`. The following addition:  
+
+```yaml
+  extraPortMappings:
+    - containerPort: 30423
+      hostPort: 30423
+      listenAddress: "0.0.0.0"
+      protocol: TCP
+```
+
+Is required to be able to reach the pods behind a NodePort service type, which exposes the same port on worker node as defined in `hostPort` key-value pair, using the port exposed by a Pod. You can create the cluster running `kind create cluster --config kind-example-config.yaml`.  
+
+The basic setups consists of two replicas of Flask application, which state is controlled by Deployment Controller, exposed by a NodePort type service to the user.  
+The Flask communicates with a MySQL instance through headless service, which exposes a Stateful Set, destined to manage the state of MySQL.
+
+```mermaid
+graph LR
+subgraph flask-blog namespace
+subgraph Flask app
+A[Service - App] --> |exposes|B[Deployment]
+B --> |controls state|E([Flask Pod])
+B --> |controls state|F([Flask Pod])
+end
+subgraph MySQL
+C[Service headless - Mysql] --> |exposes|D[Stateful Set]
+D --> |controls state|G[(MySQL Instance)]
+E -.-> |headless service DNS|C
+F -.-> |headless service DNS|C
+end
+end
+```
+
+You are able to reach the Flask Blog app by visiting localhost on port exposed by the pods (**5000**), which will go through NodePort (**30423**) on worker node.
+
+```bash
+curl localhost:5000 # or open browser and enter localhost:5000
+```
+
+All files used for deployment of the application are defined in `deployment/` folder:
+
+* `config-maps.yaml` - Describes all non-secret related data that the app requires to function properly - this includes DNS of the MySQL service, init script for database or environment variables for defining database name and operating port.
+* `secrets.yaml` - Describes all secret data that the app requires to function properly - this includes username and password of flask user, which will interact with MySQL database, root account credentials and secret keys.
+* `namespace.yaml` - Describes the namespace in kubernetes cluster, in which everything should be deployed.
+* `services.yaml` - Describes two services for exposing pods matching certain labels - one for Flask app pods, second for MySQL instance respectively.
+* `deplyoment.yaml` - Describes the Deplyoment Controller for managing state of Flask Blog pods.
+* `stateful-set.yaml` - Describes the Stateful Set Controller for managing state of MySQL instance.
+
+The order in which the infrastructure should be deployed is:  
+**namespace -> config-maps & secrets -> services -> statefulset -> deployment**
+
+It is possible to use `kubectl apply -f deployment/` to deploy all of them using single command, but the files are executed in **alphabetical order** (which may yield errors like trying to create resource in a namespace which is not yet created).
+
+### Kubernetes setup - Ingress Controller
+
+### Kubernetes setup - K8s Dashboard

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -10,8 +10,6 @@ COPY app/ app/
 
 COPY pyproject.toml .
 
-COPY .env .
-
 RUN pip install -e .
 
 RUN pip install -r app/requirements.txt

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,8 +1,24 @@
 import os
+from logging.config import dictConfig
 
 import dotenv
 from flask import Flask
 
+dictConfig({
+    "version": 1,
+    "formatters": {"default": {
+        "format": "[%(asctime)s] %(levelname)s in %(module)s: %(message)s",
+    }},
+    "handlers": {"wsgi": {
+        "class": "logging.StreamHandler",
+        "stream": "ext://flask.logging.wsgi_errors_stream",
+        "formatter": "default"
+    }},
+    "root": {
+        "level": "DEBUG",
+        "handlers": ["wsgi"]
+    }
+})
 
 def create_app(test_config=None):
     """Create and configure an instance of the Flask application."""
@@ -32,6 +48,7 @@ def create_app(test_config=None):
 
     @app.route("/hello")
     def hello():
+        app.logger.debug("Handling request to /hello route.")
         return "Hello, World!"
 
     # register the database commands

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,7 +1,7 @@
 import functools
 
-from flask import (Blueprint, flash, g, redirect, render_template, request,
-                   session, url_for)
+from flask import (Blueprint, current_app, flash, g, redirect, render_template,
+                   request, session, url_for)
 from mysql.connector import IntegrityError
 from werkzeug.security import check_password_hash, generate_password_hash
 
@@ -46,6 +46,7 @@ def register():
     Validates that the username is not already taken. Hashes the
     password for security.
     """
+    current_app.logger.debug("Handling {req_type} request to /register route.".format(req_type=request.method))
     if request.method == "POST":
         username = request.form["username"]
         password = request.form["password"]
@@ -81,6 +82,7 @@ def register():
 @bp.route("/login", methods=("GET", "POST"))
 def login():
     """Log in a registered user by adding the user id to the session."""
+    current_app.logger.debug("Handling {req_type} request to /login route.".format(req_type=request.method))
     if request.method == "POST":
         username = request.form["username"]
         password = request.form["password"]
@@ -111,5 +113,6 @@ def login():
 @bp.route("/logout")
 def logout():
     """Clear the current session, including the stored user id."""
+    current_app.logger.debug("Handling request to /logout route.")
     session.clear()
     return redirect(url_for("index"))

--- a/app/blog.py
+++ b/app/blog.py
@@ -1,5 +1,5 @@
-from flask import (Blueprint, flash, g, redirect, render_template, request,
-                   url_for)
+from flask import (Blueprint, current_app, flash, g, redirect, render_template,
+                   request, url_for)
 from werkzeug.exceptions import abort
 
 from app.auth import login_required
@@ -11,6 +11,7 @@ bp = Blueprint("blog", __name__)
 @bp.route("/")
 def index():
     """Show all the posts, most recent first."""
+    current_app.logger.debug("Handling request to / route.")
     db = get_db()
     cursor = db.cursor(dictionary=True)
     cursor.execute("USE flaskr")
@@ -55,6 +56,7 @@ def get_post(id, check_author=True):
 @login_required
 def create():
     """Create a new post for the current user."""
+    current_app.logger.debug("Handling {req_type} request to /create route.".format(req_type=request.method))
     if request.method == "POST":
         title = request.form["title"]
         body = request.form["body"]
@@ -82,6 +84,7 @@ def create():
 @login_required
 def update(id):
     """Update a post if the current user is the author."""
+    current_app.logger.debug("Handling {req_type} request to /{id}/update route.".format(req_type=request.method, id=id))
     post = get_post(id)
 
     if request.method == "POST":
@@ -114,6 +117,7 @@ def delete(id):
     Ensures that the post exists and that the logged in user is the
     author of the post.
     """
+    current_app.logger.debug("Handling {req_type} request to /{id}/delete route.".format(req_type=request.method, id=id))
     get_post(id)
     db = get_db()
     cursor = db.cursor()

--- a/app/db.py
+++ b/app/db.py
@@ -17,13 +17,19 @@ def get_db():
                 password=current_app.config["DATABASE_PASSWORD"],
                 database=current_app.config["DATABASE_NAME"]
             )
+            current_app.logger.info("Connection established with remote MySQL database {db} at {instance}:{port} as user {user}".format(
+                instance=current_app.config["DATABASE_HOST"],
+                port="3306",
+                db=current_app.config["DATABASE_NAME"],
+                user=current_app.config["DATABASE_USER"]
+            ))
         except mysql.Error as err:
             if err.errno == errorcode.ER_ACCESS_DENIED_ERROR:
-                print("Something is wrong with your user name or password")
+                current_app.logger.error("Something is wrong with your user name or password")
             elif err.errno == errorcode.ER_BAD_DB_ERROR:
-                print("Database does not exist")
+                current_app.logger.error("Database does not exist")
             else:
-                print(err)  
+                current_app.logger.error(err)  
             raise SystemExit(1) from err      
 
     return g.db
@@ -37,6 +43,7 @@ def close_db(e=None):
 
     if db is not None:
         db.close()
+        current_app.logger.debug("Closing database connection.")
 
 
 def init_db():

--- a/deployment/config-maps.yaml
+++ b/deployment/config-maps.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: flask-data
+  namespace: flask-blog
+data:
+  mysql_database_name: flaskr
+  mysql_database_port: "3306"
+  # <statefulset pod name>.<headless service name>.<namespace>.svc.cluster.local
+  # Why use headless service for stateful set?
+  # We get stable and consistent DNS naming
+  # re-created pod receives same unique identifier as before
+  # No loadbalancing - single master db, rest used as read replicas
+  mysql_headless_service_hostname: mysql-stateful-set-0.mysql-service.flask-blog.svc.cluster.local
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mysql-init-script
+  namespace: flask-blog
+data:
+  schema.sql: |
+    -- Initialize the database.
+    -- Drop any existing data and create empty tables.
+
+    DROP DATABASE IF EXISTS flaskr;
+
+    CREATE DATABASE flaskr;
+
+    USE flaskr;
+
+    DROP TABLE IF EXISTS user;
+    DROP TABLE IF EXISTS post;
+
+    CREATE TABLE user (
+      id INT NOT NULL AUTO_INCREMENT,
+      username VARCHAR(255) NOT NULL,
+      password VARCHAR(255) NOT NULL,
+      PRIMARY KEY (id),
+      UNIQUE (username)
+    );
+
+    CREATE TABLE post (
+      id INT NOT NULL AUTO_INCREMENT,
+      author_id INT NOT NULL,
+      created TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP(),
+      title VARCHAR(255) NOT NULL,
+      body VARCHAR(255) NOT NULL,
+      PRIMARY KEY (id),
+      FOREIGN KEY (author_id) REFERENCES user(id)
+    );    
+
+    GRANT SELECT, INSERT ON flaskr.* TO 'piotr'@'%';
+
+    FLUSH PRIVILEGES;

--- a/deployment/deployment.yaml
+++ b/deployment/deployment.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: flask-app-deployment
+  namespace: flask-blog
+  labels:
+      type: blog
+spec:
+  selector:
+    matchLabels:
+      app: flask-app
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: flask-app
+        type: blog
+    spec:
+      containers:
+      - name: flask-app
+        image: blog:v1.0.0
+        # https://iximiuz.com/en/posts/kubernetes-kind-load-docker-image/
+        imagePullPolicy: Never
+        resources:
+          limits:
+            memory: "256Mi"
+            cpu: "500m"
+        env:
+          - name: MYSQL_PORT
+            valueFrom:
+              configMapKeyRef:
+                key: mysql_database_port
+                name: flask-data
+          - name: MYSQL_DB_NAME
+            valueFrom:
+              configMapKeyRef:
+                key: mysql_database_name
+                name: flask-data
+          - name: MYSQL_HOSTNAME
+            valueFrom:
+              configMapKeyRef:
+                key: mysql_headless_service_hostname
+                name: flask-data
+          - name: MYSQL_FLASK_USER
+            valueFrom:
+              secretKeyRef:
+                key: username
+                name: mysql-flask-auth
+          - name: MYSQL_FLASK_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: password
+                name: mysql-flask-auth
+          - name: FLASK_APP_SECRET_KEY
+            valueFrom:
+              secretKeyRef:
+                key: flask_app_secret_key
+                name: flask-secret-key
+        ports:
+        - containerPort: 5000

--- a/deployment/namespace.yaml
+++ b/deployment/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: flask-blog

--- a/deployment/secrets.yaml
+++ b/deployment/secrets.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysql-superuser-auth
+  namespace: flask-blog
+type: kubernetes.io/basic-auth
+stringData:
+  username: root
+  password: admin
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysql-flask-auth
+  namespace: flask-blog
+type: kubernetes.io/basic-auth
+stringData:
+  username: piotr
+  password: piotr
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: flask-secret-key
+  namespace: flask-blog
+type: Opaque
+data:
+  flask_app_secret_key: 6cFKoOLSEeOZX5y8yQNqk5WWPBMW

--- a/deployment/services.yaml
+++ b/deployment/services.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: flask-app-service
+  namespace: flask-blog
+  labels:
+    app: flask-app  
+spec:
+  selector:
+    type: blog
+  type: NodePort
+  ports:
+  - port: 5000
+    targetPort: 5000
+    nodePort: 30423
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql-service
+  namespace: flask-blog
+  labels:
+    app: flask-app    
+spec:
+  ports:
+    - port: 3306
+  selector:
+    db: mysql-instance
+  clusterIP: None

--- a/deployment/stateful-set.yaml
+++ b/deployment/stateful-set.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mysql-stateful-set
+  namespace: flask-blog
+spec:
+  selector:
+    matchLabels:
+      db: mysql-instance
+  serviceName:  mysql-service
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        db: mysql-instance
+        app: flask-app
+    spec:
+      containers:
+      - name: mysql
+        image: mysql:8.0.32
+        ports:
+        - containerPort: 3306
+          name: database
+        volumeMounts:
+        - name: data
+          mountPath: /var/lib/mysql
+        - name: init-script
+          mountPath: "/docker-entrypoint-initdb.d"
+          readOnly: true
+        env:
+          - name: MYSQL_ROOT_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: password
+                name: mysql-superuser-auth
+          - name: MYSQL_USER
+            valueFrom:
+              secretKeyRef:
+                key: username
+                name: mysql-flask-auth
+          - name: MYSQL_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: password
+                name: mysql-flask-auth
+  
+      volumes:
+        - name: init-script
+          configMap:
+            name: mysql-init-script
+
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 5Gi

--- a/kind-example-config.yaml
+++ b/kind-example-config.yaml
@@ -1,0 +1,14 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  image: kindest/node:v1.26.0
+  extraPortMappings:
+    - containerPort: 30423
+      hostPort: 30423
+      listenAddress: "0.0.0.0"
+      protocol: TCP
+- role: worker
+  image: kindest/node:v1.26.0
+- role: worker
+  image: kindest/node:v1.26.0


### PR DESCRIPTION
* Remove copying .env file over when creating an image
Kubernetes Pod running container with Flask app
will be using Secrets and ConfigMap Controllers for
retrieving environmental data

* Add error/info/debug logging for app
* Add basic logger configuration
* Add configuration file for Kind, which enables
running Kubernetes cluster locally

* The config defined multi-node setup:
  * Single control-plane node
  * Two worker nodes
It also exposes port to host, which is used by services
to allow for reaching the services from outside using
NodePort service type
* Add YAML files responsible for provisioning
the blog Flask application on kubernetes cluster

* The infrastructure includes:
  * Config maps controllers with env data for flask/mysql
  * Secrets controllers with credentials data for flask/mysql
  * Namespace for isolating the application resources within cluster
  * Two services - one for loadbalacing traffic to multiple replicas
of stateless flask app, the other (headless) for reliable DNS
identifiers for MySQL
  * Deployment Controller for Flask Blog application
  * Stateful Set Controller for MySQL database