### PR TITLE
Helm: Add EFK stack as a chart dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,15 @@ Then, we can install the blog application using Helm package manager
 
 ```bash
 # In project's root directory
-helm install flask-blog --generate-name --atomic --namespace <name of the namespace> --dependency-update
+helm install flask-blog --generate-name --atomic --namespace <YOUR_NAMESPACE> --dependency-update
 ```
 
 `--atomic` flag removes the resources in case of an installation failure.
+
+Helm Chart notes contain important information regarding application, including access, retrieving the IP address and/or ports. It also explain how to create and visualize data source from fluentd logs in Kibana Dashboard.\
+The Helm Chart notes will be displayed each time a new chart release is being installed or upgraded.
+To see the notes at any point, run
+
+```bash
+helm get notes <YOUR_RELEASE_NAME> -n <YOUR_NAMESPACE>
+```

--- a/flask-blog/charts/efk/.helmignore
+++ b/flask-blog/charts/efk/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/flask-blog/charts/efk/Chart.yaml
+++ b/flask-blog/charts/efk/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-name: flask-blog
-description: A Helm chart for Kubernetes Flask Blog Application
+name: efk
+description: A Helm chart for Kubernetes EFK stack for monitoring Flask Blog Application
 
 # A chart can be either an 'application' or a 'library' chart.
 #
@@ -15,18 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.0.0"
+appVersion: "1.16.0"
 
 kubeVersion: "1.26.x"
-
-dependencies:
-  - name: mysql
-    version: ^1.0.0
-  - name: efk
-    version: ^0.1.0

--- a/flask-blog/charts/efk/elastic-fluent.conf
+++ b/flask-blog/charts/efk/elastic-fluent.conf
@@ -1,0 +1,12 @@
+<match **>
+    @type elasticsearch
+    host {{ include "efk.elasticsearchName" . }}
+    port {{ .Values.elasticsearch.options.port }}
+    scheme http
+    index_name fluentd
+    type_name fluentd
+    include_timestamp true
+    include_tag_key true
+    logstash_format false
+    flush_interval 10s
+</match>

--- a/flask-blog/charts/efk/fluent.conf
+++ b/flask-blog/charts/efk/fluent.conf
@@ -1,0 +1,2 @@
+@include pods-fluent.conf
+@include elastic-fluent.conf

--- a/flask-blog/charts/efk/pods-fluent.conf
+++ b/flask-blog/charts/efk/pods-fluent.conf
@@ -1,0 +1,18 @@
+<source>
+    @type tail
+    read_from_head true
+    tag kubernetes.*
+    path /var/log/containers/flask*.log,/var/log/containers/mysql*.log
+    pos_file /var/log/fluentd-container.log.pos
+    exclude_path ["/var/log/containers/fluent*.log"]
+    <parse>
+    @type regexp
+    expression /^(?<time>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z)\s(?<stream>stderr|stdout)\s*(?<char>[A-Z]){1}\s(?<message>.+)$/i
+    </parse>
+</source>
+
+# Requires RBAC set for accessing Kubernetes API
+<filter kubernetes.**>
+    @id filter_kubernetes_metadata
+    @type kubernetes_metadata
+</filter>

--- a/flask-blog/charts/efk/templates/_helpers.tpl
+++ b/flask-blog/charts/efk/templates/_helpers.tpl
@@ -1,0 +1,175 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "efk.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "efk.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "efk.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Expand the name of the chart for elasticsearch resources
+*/}}
+{{- define "efk.elasticsearchName" -}}
+{{- if .Values.elasticsearchNameOverride }}
+{{- printf "%s-elasticsearch" .Values.elasticsearchNameOverride | trunc 63 }}
+{{- else }}
+{{- printf "%s-elasticsearch" (include "efk.name" . ) | trunc 63 }}
+{{- end }}
+{{- end }}
+
+{{/*
+Expand the name of the chart for kibana resources
+*/}}
+{{- define "efk.kibanaName" -}}
+{{- if .Values.kibanaNameOverride }}
+{{- printf "%s-kibana" .Values.kibanaNameOverride | trunc 63 }}
+{{- else }}
+{{- printf "%s-kibana" (include "efk.name" .) | trunc 63 }}
+{{- end }}
+{{- end }}
+
+{{/*
+Expand the name of the chart for fluentd resources
+*/}}
+{{- define "efk.fluentdName" -}}
+{{- if .Values.fluentdNameOverride }}
+{{- printf "%s-fluentd" .Values.fluentdNameOverride | trunc 63 }}
+{{- else }}
+{{- printf "%s-fluentd" (include "efk.name" .) | trunc 63 }}
+{{- end }}
+{{- end }}
+
+
+{{/*
+Common labels for ElasticSearch
+*/}}
+{{- define "efk.elasticsearch.labels" -}}
+helm.sh/chart: {{ include "efk.chart" . }}
+{{ include "efk.elasticsearch.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: blog-app
+{{- end }}
+
+{{/*
+Common labels for Kibana
+*/}}
+{{- define "efk.kibana.labels" -}}
+helm.sh/chart: {{ include "efk.chart" . }}
+{{ include "efk.kibana.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: blog-app
+{{- end }}
+
+{{/*
+Common labels for Fluentd
+*/}}
+{{- define "efk.fluentd.labels" -}}
+helm.sh/chart: {{ include "efk.chart" . }}
+{{ include "efk.fluentd.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: blog-app
+{{- end }}
+
+{{/*
+Selector labels for ElasticSearch
+*/}}
+{{- define "efk.elasticsearch.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "efk.elasticsearchName" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: flask-monitoring-stack
+{{- end }}
+
+{{/*
+Selector labels for Kibana
+*/}}
+{{- define "efk.kibana.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "efk.kibanaName" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: flask-monitoring-stack
+{{- end }}
+
+{{/*
+Selector labels for Fluentd
+*/}}
+{{- define "efk.fluentd.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "efk.fluentdName" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: flask-monitoring-stack
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "efk.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "efk.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Retrieve Elasticsearch image using tag, digest of default AppVersion
+*/}}
+{{- define "efk.elasticsearch.getImage" -}}
+{{- if .Values.elasticsearch.image.digest }}
+{{ .Values.elasticsearch.image.repository }}@{{ .Values.elasticsearch.image.digest }}
+{{- else }}
+{{- .Values.elasticsearch.image.repository }}:{{- .Values.elasticsearch.image.tag }}
+{{- end }}
+{{- end }}
+
+{{/*
+Retrieve Kibana image using tag, digest of default AppVersion
+*/}}
+{{- define "efk.kibana.getImage" -}}
+{{- if .Values.kibana.image.digest }}
+{{ .Values.kibana.image.repository }}@{{ .Values.kibana.image.digest }}
+{{- else }}
+{{- .Values.kibana.image.repository }}:{{- .Values.kibana.image.tag }}
+{{- end }}
+{{- end }}
+
+{{/*
+Retrieve Fluentd image using tag, digest of default AppVersion
+*/}}
+{{- define "efk.fluentd.getImage" -}}
+{{- if .Values.fluentd.image.digest }}
+{{ .Values.fluentd.image.repository }}@{{ .Values.fluentd.image.digest }}
+{{- else }}
+{{- .Values.fluentd.image.repository }}:{{- .Values.fluentd.image.tag }}
+{{- end }}
+{{- end }}

--- a/flask-blog/charts/efk/templates/elasticsearch-cm.yaml
+++ b/flask-blog/charts/efk/templates/elasticsearch-cm.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "efk.elasticsearchName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+   {{- include "efk.elasticsearch.labels" . | nindent 4 }}
+data:
+  {{- .Values.elasticsearch.options | toYaml | nindent 2 }}
+  elasticsearch.yml: |
+    {{- .Values.elasticsearch.config | toYaml | nindent 4 }}

--- a/flask-blog/charts/efk/templates/elasticsearch-deploy.yaml
+++ b/flask-blog/charts/efk/templates/elasticsearch-deploy.yaml
@@ -1,0 +1,64 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "efk.elasticsearchName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "efk.elasticsearch.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "efk.elasticsearch.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "efk.elasticsearch.labels" . | nindent 8 }}
+    spec:
+      # https://www.elastic.co/guide/en/elasticsearch/reference/8.6/docker.html#_set_vm_max_map_count_to_at_least_262144
+      initContainers:
+        - name: vm-max-fix
+          image: busybox
+          imagePullPolicy: IfNotPresent
+          command: ["sysctl", "-w", "vm.max_map_count=262144"]
+          securityContext:
+            privileged: true
+      tolerations:
+        - key: kubernetes.io/hostname
+          operator: Equal
+          value: kind-control-plane
+          effect: NoSchedule
+      containers:
+        - name: {{ .Chart.Name }}
+          image: {{ include "efk.elasticsearch.getImage" . }}
+          imagePullPolicy: {{ .Values.elasticsearch.image.pullPolicy}}
+          ports:
+            - containerPort: {{ .Values.elasticsearch.options.port | int }}
+            - containerPort: 9300
+          env:
+            - name: node.name
+              valueFrom:
+                configMapKeyRef:
+                  key: node_name
+                  name: {{ include "efk.elasticsearchName" . }}
+            - name: bootstrap.memory_lock
+              valueFrom:
+                configMapKeyRef:
+                  key: bootstrap_memory_lock
+                  name: {{ include "efk.elasticsearchName" . }}
+            - name: ES_JAVA_OPTS
+              valueFrom:
+                configMapKeyRef:
+                  key: java_options
+                  name: {{ include "efk.elasticsearchName" . }}
+          resources:
+            requests:
+              {{- .Values.elasticsearch.resources.requests | toYaml | nindent 14 }}
+            limits:
+              {{- .Values.elasticsearch.resources.limits | toYaml | nindent 14 }}
+          volumeMounts:
+            {{- .Values.elasticsearch.volumeMounts | toYaml | nindent 12 }}
+      volumes:
+        - name: elasticsearch-config
+          configMap:
+            name: {{ include "efk.elasticsearchName" . }}

--- a/flask-blog/charts/efk/templates/elasticsearch-svc.yaml
+++ b/flask-blog/charts/efk/templates/elasticsearch-svc.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "efk.elasticsearchName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "efk.elasticsearch.labels" . | nindent 4 }}
+spec:
+  selector:
+    {{- include "efk.elasticsearch.selectorLabels" . | nindent 4 }}
+  ports:
+    - protocol: TCP
+      name: http
+      port: {{ .Values.elasticsearch.options.port | int }}
+      targetPort: {{ .Values.elasticsearch.options.port | int }}

--- a/flask-blog/charts/efk/templates/fluentd-cm.yaml
+++ b/flask-blog/charts/efk/templates/fluentd-cm.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "efk.fluentdName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "efk.fluentd.labels" . | nindent 4 }}
+data:
+  {{- .Values.fluentd.config | toYaml | nindent 2 }}
+  {{- tpl (.Files.Glob "*fluent*.conf").AsConfig . | nindent 2 }}

--- a/flask-blog/charts/efk/templates/fluentd-daemonset.yaml
+++ b/flask-blog/charts/efk/templates/fluentd-daemonset.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "efk.fluentdName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "efk.fluentd.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "efk.fluentd.selectorLabels" . | nindent 8 }}
+  template:
+    metadata:
+      labels:
+        {{- include "efk.fluentd.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccount: {{ include "efk.fluentdName" . }}
+      serviceAccountName: {{ include "efk.fluentdName" . }}
+      tolerations:
+        - key: kubernetes.io/hostname
+          operator: Equal
+          value: kind-control-plane
+          effect: NoSchedule
+      containers:
+        - name: {{ .Chart.Name }}
+          image: {{ include "efk.fluentd.getImage" . }}
+          imagePullPolicy: {{ .Values.fluentd.image.pullPolicy}}
+          env:
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: FLUENT_ELASTICSEARCH_HOST
+              valueFrom:
+                configMapKeyRef:
+                  key: elasticsearch_host
+                  name: {{ include "efk.fluentdName" . }}
+            - name: FLUENT_ELASTICSEARCH_PORT
+              valueFrom:
+                configMapKeyRef:
+                  key: elasticsearch_port
+                  name: {{ include "efk.fluentdName" . }}
+            - name: FLUENT_ELASTICSEARCH_SCHEME
+              valueFrom:
+                configMapKeyRef:
+                  key: elasticsearch_scheme
+                  name: {{ include "efk.fluentdName" . }}
+          resources:
+            requests:
+              {{- .Values.fluentd.resources.requests | toYaml | nindent 14 }}
+            limits:
+              {{- .Values.fluentd.resources.limits | toYaml | nindent 14 }}
+          volumeMounts:
+            {{- .Values.fluentd.volumeMounts | toYaml | nindent 12 }}
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: fluentd-config
+          configMap:
+            name: {{ include "efk.fluentdName" . }}
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers

--- a/flask-blog/charts/efk/templates/fluentd-rbac.yaml
+++ b/flask-blog/charts/efk/templates/fluentd-rbac.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "efk.fluentdName" . }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "efk.fluentdName" . }}
+rules:
+  {{- .Values.fluentd.serviceAccountRules | toYaml | nindent 2 }}
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "efk.fluentdName" . }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "efk.fluentdName" . }}
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "efk.fluentdName" . }}
+    namespace: {{ .Release.Namespace }}

--- a/flask-blog/charts/efk/templates/kibana-cm.yaml
+++ b/flask-blog/charts/efk/templates/kibana-cm.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "efk.kibanaName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "efk.kibana.labels" . | nindent 4 }}
+data:
+  kibana.yml: |
+    {{- .Values.kibana.config | toYaml | nindent 4 }}
+  elasticsearch_hosts: '["http://{{ include "efk.elasticsearchName" . }}:{{ .Values.elasticsearch.options.port }}"]'

--- a/flask-blog/charts/efk/templates/kibana-deploy.yaml
+++ b/flask-blog/charts/efk/templates/kibana-deploy.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "efk.kibanaName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "efk.kibana.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "efk.kibana.selectorLabels" . | nindent 6 }}
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        {{- include "efk.kibana.selectorLabels" . | nindent 8 }}
+    spec:
+      tolerations:
+        - key: kubernetes.io/hostname
+          operator: Equal
+          value: kind-control-plane
+          effect: NoSchedule
+      containers:
+        - name: {{ .Chart.Name }}
+          image: {{ include "efk.kibana.getImage" . }}
+          imagePullPolicy: {{ .Values.kibana.image.pullPolicy}}
+          env:
+            - name: ELASTICSEARCH_HOSTS
+              valueFrom:
+                configMapKeyRef:
+                  key: elasticsearch_hosts
+                  name: {{ include "efk.kibanaName" . }}
+          ports:
+            - containerPort: {{ index .Values.kibana.config "server.port" | int }}
+          resources:
+            requests:
+              {{- .Values.kibana.resources.requests | toYaml | nindent 14 }}
+            limits:
+              {{- .Values.kibana.resources.limits | toYaml | nindent 14 }}
+          volumeMounts:
+            - name: kibana-config
+              mountPath: "/usr/share/kibana/config/kibana.yml"
+              subPath: kibana.yml
+      volumes:
+        - name: kibana-config
+          configMap:
+            name: {{ include "efk.kibanaName" . }}

--- a/flask-blog/charts/efk/templates/kibana-svc.yaml
+++ b/flask-blog/charts/efk/templates/kibana-svc.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "efk.kibanaName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "efk.kibana.labels" . | nindent 4 }}
+spec:
+  selector:
+    {{- include "efk.kibana.selectorLabels" . | nindent 4 }}
+  ports:
+    - protocol: TCP
+      name: http
+      port: {{ index .Values.kibana.config "server.port" | int }}
+      targetPort: {{ index .Values.kibana.config "server.port" | int }}

--- a/flask-blog/charts/efk/values.yaml
+++ b/flask-blog/charts/efk/values.yaml
@@ -1,0 +1,98 @@
+# Default values for efk.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+nameOverride: ""
+fullnameOverride: ""
+elasticsearchNameOverride: ""
+kibanaNameOverride: ""
+fluentdNameOverride: ""
+
+elasticsearch:
+  image:
+    repository: docker.elastic.co/elasticsearch/elasticsearch
+    tag: 8.6.2
+    digest:
+    pullPolicy: IfNotPresent
+  resources:
+    limits:
+      memory: 4Gi
+      cpu: 2000m
+    requests:
+      memory: 4Gi
+      cpu: 2000m
+  options:
+    node_name: elasticsearch
+    bootstrap_memory_lock: "false"
+    java_options: "-Xms512m -Xmx512m"
+    port: "9200"
+  config:
+    xpack.security.enabled: "false"
+    xpack.security.transport.ssl.enabled: "false"
+    xpack.security.http.ssl.enabled: "false"
+    network.host: "0.0.0.0"
+    discovery.type: single-node
+  volumeMounts:
+    - name: elasticsearch-config
+      mountPath: /usr/share/elasticsearch/config/elasticsearch.yml
+      subPath: elasticsearch.yml
+
+fluentd:
+  image:
+    repository: fluent/fluentd-kubernetes-daemonset
+    tag: v1-debian-elasticsearch
+    digest:
+    pullPolicy: IfNotPresent
+  resources:
+    limits:
+      memory: 200Mi
+      cpu: 100m
+    requests:
+      memory: 200Mi
+      cpu: 100m
+  config:
+    elasticsearch_host: elasticsearch
+    elasticsearch_port: "9200"
+    elasticsearch_scheme: http
+  volumeMounts:
+    - name: fluentd-config
+      mountPath: /fluentd/etc
+    - name: varlog
+      mountPath: /var/log
+    - name: varlibdockercontainers
+      mountPath: /var/lib/docker/containers
+      readOnly: true
+  serviceAccountRules:
+    - apiGroups:
+        - ""
+      resources:
+        - pods
+        - namespaces
+      verbs:
+        - get
+        - list
+        - watch
+
+kibana:
+  image:
+    repository: docker.elastic.co/kibana/kibana
+    tag: 8.6.2
+    digest:
+    pullPolicy: IfNotPresent
+  resources:
+    limits:
+      memory: 4Gi
+      cpu: 2000m
+    requests:
+      memory: 2Gi
+      cpu: 1000m
+  config:
+    elasticsearch.ssl.verificationMode: none
+    server.host: "0.0.0.0"
+    server.port: "5601"
+    server.ssl.enabled: "false"
+    status.allowAnonymous: "true"
+  volumeMounts:
+    - name: kibana-config
+      mountPath: /usr/share/kibana/config/kibana.yml
+      subPath: kibana.yml

--- a/flask-blog/templates/NOTES.txt
+++ b/flask-blog/templates/NOTES.txt
@@ -1,7 +1,27 @@
+/*
+* ACCESSING THE FLASK BLOG WEBSITE
+*/
+
 1. Get the application URL by running these commands:
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "flask-blog.name" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+
 2. Visit URL defined by aforementioned operations
     echo http://$NODE_IP:$NODE_PORT
+
 3. If you kind cluster config does have an extra mapping configuration, you can visit http://localhost:$NODE_PORT
+
+/*
+* CONFIGURING KIBANA TO VISUALIZE LOGS FROM FLUENTD
+*/
+
+4. To visit the Kibana dashboard, run command to forward the traffic to your local host:
+  export KIBANA_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].port}" services {{ include "efk.kibanaName" .Subcharts.efk }})
+  kubectl port-forward svc/{{ include "efk.kibanaName" .Subcharts.efk }} $KIBANA_PORT:5601 -n {{ .Release.Namespace }}
+
+5. Visit localhost:5601 on your local browser to access Kibana. There are no credentials required, since the access to Elasticsearch cluster is set to anonymous.
+
+6. Go to Stack management -> Data Views (Under Kibana section) and create a new data view. You should see a single source of data called "fluentd". Create a data view by specifying a name and index pattern, which would match the "fluentd" source.
+
+7. Now you can go to Analytics -> Discover section and see all your Fluentd logs being visualized on Kibana Dashboard
 


### PR DESCRIPTION
Configure Elasticsearch, Fluentd and Kibana as a single application, deployed using Helm Chart
Include said application as a subchart dependency for flask-blog application